### PR TITLE
fixed html5 standards

### DIFF
--- a/assets/tmpl/javascript.start.html
+++ b/assets/tmpl/javascript.start.html
@@ -1,1 +1,1 @@
-<script type="text/javascript">
+<script>


### PR DESCRIPTION
type attribute not needed for javascript in html5, its default scripting language now